### PR TITLE
Feature/fix retry upload crash

### DIFF
--- a/Classes/MapViewController.m
+++ b/Classes/MapViewController.m
@@ -157,7 +157,7 @@
     [super viewDidLoad];
 	self.navigationController.navigationBar.barStyle = UIBarStyleBlackTranslucent;
     self.navigationController.navigationBarHidden = NO;
-    self.locationManager = [[[CLLocationManager alloc] init] autorelease];
+    self.locationManager = [[CLLocationManager alloc] init];
     self.locationManager.delegate = self;
     // Check for iOS 8. Without this guard the code will crash with "unknown selector" on iOS 7.
     if ([self.locationManager respondsToSelector:@selector(requestAlwaysAuthorization)]) {
@@ -386,93 +386,9 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
-    
-    UIImage *thumbnailOriginal;
-    thumbnailOriginal = [self screenshot];
-    
-    CGRect clippedRect  = CGRectMake(self.view.frame.origin.x, self.view.frame.origin.y+160, self.view.frame.size.width, self.view.frame.size.height);
-    CGImageRef imageRef = CGImageCreateWithImageInRect([thumbnailOriginal CGImage], clippedRect);
-    UIImage *newImage   = [UIImage imageWithCGImage:imageRef];
-    CGImageRelease(imageRef);
-    
-    CGSize size;
-    size.height = 72;
-    size.width = 72;
-    
-    UIImage *thumbnail;
-    thumbnail = shrinkImage(newImage, size);
-    
-    NSData *thumbnailData = [[[NSData alloc] initWithData:UIImageJPEGRepresentation(thumbnail, 0)] autorelease];
-    NSLog(@"Size of Thumbnail Image(bytes):%lu",(unsigned long)[thumbnailData length]);
-    NSLog(@"Size: %f, %f", thumbnail.size.height, thumbnail.size.width);
-    
-    [delegate getTripThumbnail:thumbnailData];
+    [self.locationManager stopUpdatingLocation];
     [delegate release];
 }
-
-
-UIImage *shrinkImage(UIImage *original, CGSize size) {
-    CGFloat scale = [UIScreen mainScreen].scale;
-    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    
-    CGContextRef context = CGBitmapContextCreate(NULL, size.width * scale,
-                                                 size.height * scale, 8, 0, colorSpace, kCGImageAlphaPremultipliedFirst);
-    CGContextDrawImage(context,
-                       CGRectMake(0, 0, size.width * scale, size.height * scale),
-                       original.CGImage);
-    CGImageRef shrunken = CGBitmapContextCreateImage(context);
-    UIImage *final = [UIImage imageWithCGImage:shrunken];
-    
-    CGContextRelease(context);
-    CGImageRelease(shrunken);
-    CGColorSpaceRelease(colorSpace);
-    return final;
-}
-
-
-- (UIImage*)screenshot
-{
-    NSLog(@"Screen Shoot");
-    // Create a graphics context with the target size
-    CGSize imageSize = [[UIScreen mainScreen] bounds].size;
-    UIGraphicsBeginImageContextWithOptions(imageSize, NO, 0);
-    
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    
-    // Iterate over every window from back to front
-    for (UIWindow *window in [[UIApplication sharedApplication] windows])
-    {
-        if (![window respondsToSelector:@selector(screen)] || [window screen] == [UIScreen mainScreen])
-        {
-            // -renderInContext: renders in the coordinate space of the layer,
-            // so we must first apply the layer's geometry to the graphics context
-            CGContextSaveGState(context);
-            // Center the context around the window's anchor point
-            CGContextTranslateCTM(context, [window center].x, [window center].y);
-            // Apply the window's transform about the anchor point
-            CGContextConcatCTM(context, [window transform]);
-            // Offset by the portion of the bounds left of and above the anchor point
-            CGContextTranslateCTM(context,
-                                  -[window bounds].size.width * [[window layer] anchorPoint].x,
-                                  -[window bounds].size.height * [[window layer] anchorPoint].y+50);
-            
-            // Render the layer hierarchy to the current context
-            [[window layer] renderInContext:context];
-            
-            // Restore the context
-            CGContextRestoreGState(context);
-        }
-    }
-    
-    // Retrieve the screenshot image
-    UIImage *screenImage = UIGraphicsGetImageFromCurrentImageContext();
-    
-    UIGraphicsEndImageContext();
-    
-    return screenImage;
-}
-
-
 
 /*
  // Override to allow orientations other than the default portrait orientation.
@@ -620,12 +536,8 @@ UIImage *shrinkImage(UIImage *original, CGSize size) {
 }
 
 - (void)dealloc {
-    self.trip = nil;
-    self.doneButton = nil;
-    self.flipButton = nil;
-    self.infoView = nil;
-    self.routeLine = nil;
-    self.delegate = nil;
+    
+    [super dealloc];
     
     [delegate release];
 	[doneButton release];
@@ -635,8 +547,6 @@ UIImage *shrinkImage(UIImage *original, CGSize size) {
     [routeLine release];
     
     [mapView release];
-    
-    [super dealloc];
 }
 
 

--- a/Classes/RecordTripViewController.m
+++ b/Classes/RecordTripViewController.m
@@ -95,7 +95,7 @@
         return appDelegate.locationManager;
     }
 	
-    appDelegate.locationManager = [[[CLLocationManager alloc] init] autorelease];
+    appDelegate.locationManager = [[CLLocationManager alloc] init];
     appDelegate.locationManager.desiredAccuracy = kCLLocationAccuracyBest;
     //locationManager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters;
     appDelegate.locationManager.delegate = self;
@@ -818,6 +818,11 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
 }
 
+-(void) viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [self.locationManager stopUpdatingLocation];
+}
 
 - (void)viewDidDisappear:(BOOL)animated
 {
@@ -1026,7 +1031,6 @@ shouldSelectViewController:(UIViewController *)viewController
     self.appDelegate = nil;
     speedCounter = nil;
     
-//    [appDelegate.locationManager release];
     [appDelegate release];
     [infoButton release];
     [saveButton release];

--- a/Classes/SavedTripsViewController.m
+++ b/Classes/SavedTripsViewController.m
@@ -793,6 +793,7 @@
     // load map view of saved trip
     MapViewController *mvc = [[MapViewController alloc] initWithTrip:trip];
     [[self navigationController] pushViewController:mvc animated:YES];
+    
     [mvc release];
 }
 
@@ -1047,6 +1048,7 @@
 
 
 - (void)dealloc {
+
     self.trips = nil;
     self.managedObjectContext = nil;
     self.delegate = nil;

--- a/Cycle Philly.xcodeproj/project.pbxproj
+++ b/Cycle Philly.xcodeproj/project.pbxproj
@@ -835,7 +835,7 @@
 				LastUpgradeCheck = 0510;
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
-						DevelopmentTeam = L93755WP84;
+						DevelopmentTeam = 4R28S5TJB2;
 					};
 				};
 			};


### PR DESCRIPTION
Fixes crashes when navigating back from trip map view to trip list, or after re-attempting upload of a previously recorded trip.

The issue was that the location manager added in 6d8a17d4ed8f020cc24ccd956b5d2b5d3cf5dc77 was being over-released in 3c904b3eeb62c2b5f3b635635454cb1828e44fdc.

However, the location manager is leaking memory, and should probably be replaced by a singleton.

This also removes the unused trip screenshot grabber.